### PR TITLE
adds seed file and foreign keys to artwork_collection join table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
+.env*

--- a/Gemfile
+++ b/Gemfile
@@ -44,10 +44,11 @@ gem "bootsnap", require: false
 
 # Use Sass to process CSS
 gem "sassc-rails"
+gem 'faker'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
-
+gem "cloudinary"
 gem "devise"
 gem "autoprefixer-rails"
 gem "font-awesome-sass", "~> 6.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
+    aws_cf_signer (0.1.3)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.16.0)
@@ -92,6 +93,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cloudinary (1.25.0)
+      aws_cf_signer
+      rest-client (>= 2.0.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -104,17 +108,24 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
     erubi (1.12.0)
     execjs (2.8.1)
+    faker (3.1.1)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     font-awesome-sass (6.3.0)
       sassc (~> 2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -136,6 +147,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
     minitest (5.17.0)
     msgpack (1.6.0)
@@ -148,6 +162,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
@@ -197,6 +212,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -229,6 +249,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -257,9 +280,11 @@ DEPENDENCIES
   autoprefixer-rails
   bootsnap
   capybara
+  cloudinary
   debug
   devise
   dotenv-rails
+  faker
   font-awesome-sass (~> 6.1)
   jbuilder
   jsbundling-rails

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -1,0 +1,6 @@
+class CollectionsController < ApplicationController
+  def show
+    @collection = Collection.find(params[:id])
+    @artworks = @collection.artworks
+  end
+end

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -1,4 +1,6 @@
 class Artwork < ApplicationRecord
   belongs_to :user
   has_many :artwork_collections
+  has_many :collections, through: :artwork_collections
+  has_one_attached :photo
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,3 +1,5 @@
 class Collection < ApplicationRecord
+  has_many :artwork_collections
   has_many :artworks, through: :artwork_collections
+  has_one_attached :photo
 end

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -1,0 +1,15 @@
+<div class="container">
+  <h1><%= @collection.title %></h1>
+  <% @artworks.each do |artwork| %>
+    <div class="row">
+      <div class="col-md-4">
+        <%= cl_image_tag artwork.photo.key, width: 400, height: 300, crop: :fill %>
+      </div>
+      <div class="col-md-8">
+        <h3><%= artwork.title %></h3>
+        <p><%= artwork.price %></p>
+        <p><%= artwork.user.first_name %> <%= artwork.user.last_name %></p>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,10 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+cloudinary:
+  service: Cloudinary
+  folder: <%= Rails.env %>
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/db/migrate/20230225163257_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20230225163257_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/migrate/20230227100128_add_foreign_keys_to_artwork_collections.rb
+++ b/db/migrate/20230227100128_add_foreign_keys_to_artwork_collections.rb
@@ -1,0 +1,6 @@
+class AddForeignKeysToArtworkCollections < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :artwork_collections, :artwork, null: false, foreign_key: true
+    add_reference :artwork_collections, :collection, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,45 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_25_143214) do
+ActiveRecord::Schema[7.0].define(version: 2023_02_27_100128) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "artwork_collections", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "artwork_id", null: false
+    t.bigint "collection_id", null: false
+    t.index ["artwork_id"], name: "index_artwork_collections_on_artwork_id"
+    t.index ["collection_id"], name: "index_artwork_collections_on_collection_id"
   end
 
   create_table "artworks", force: :cascade do |t|
@@ -58,5 +90,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_25_143214) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "artwork_collections", "artworks"
+  add_foreign_key "artwork_collections", "collections"
   add_foreign_key "artworks", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+require "open-uri"
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #
@@ -5,3 +6,50 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+puts "Cleaning database..."
+Artwork.destroy_all
+User.destroy_all
+Collection.destroy_all
+ArtworkCollection.destroy_all
+
+puts "Creating user..."
+joey = User.create!(first_name: "Joey", last_name: "Artist", email: "joeyartist@email.com", password: "123456")
+
+puts "Creating collections..."
+first_collection = Collection.new(title: "New & Noteworthy", description: "The crème de la crème of the newest Artichoke additions")
+file = URI.open("https://source.unsplash.com/random/?art")
+first_collection.photo.attach(io: file, filename: "first_collection.png", content_type: "image/png")
+first_collection.save!
+second_collection = Collection.create!(title: "Bold Bids", description: "How much? These eyecatching pieces are causing a stir")
+file = URI.open("https://source.unsplash.com/random/?art")
+second_collection.photo.attach(io: file, filename: "second_collection.png", content_type: "image/png")
+second_collection.save!
+third_collection = Collection.create!(title: "Exhibiting Artists", description: "Showcasing the artists who are doing great things")
+file = URI.open("https://source.unsplash.com/random/?art")
+third_collection.photo.attach(io: file, filename: "third_collection.png", content_type: "image/png")
+third_collection.save!
+fourth_collection = Collection.create!(title: "Gems under £500", description: "Grab a bargain for the downstairs toilet")
+file = URI.open("https://source.unsplash.com/random/?art")
+fourth_collection.photo.attach(io: file, filename: "fourth_collection.png", content_type: "image/png")
+fourth_collection.save!
+
+puts "Creating art..."
+mona = { title: "Mona Lisa", price: 100, user: joey }
+scream = { title: "The Scream", price: 200, user: joey }
+pitchfork = { title: "American Gothic", price: 300, user: joey }
+diners = { title: "Nighthawks", price: 400, user: joey }
+
+[mona, scream, pitchfork, diners].each do |attributes|
+  artwork = Artwork.new(attributes)
+  file = URI.open("https://source.unsplash.com/random/?#{attributes[:title]}")
+  artwork.photo.attach(io: file, filename: "#{attributes[:title]}.png", content_type: "image/png")
+  artwork.save!
+  puts "Created #{artwork.title}"
+  ArtworkCollection.create!(artwork: artwork, collection: first_collection)
+  ArtworkCollection.create!(artwork: artwork, collection: second_collection)
+  ArtworkCollection.create!(artwork: artwork, collection: third_collection)
+  ArtworkCollection.create!(artwork: artwork, collection: fourth_collection)
+end
+
+puts "Finished!"

--- a/test/controllers/collections_controller_test.rb
+++ b/test/controllers/collections_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CollectionsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This includes a seed file that adds 4 x collections and 4 x artworks. Each collection has the same 4 artworks. All collections and artworks have images, sourced from Unsplash by carrying out a search for their title and picking a random image.

Cloudinary is added here (you just need to add the API key to a .env file).

TO-DO add Cloudinary to Heroku, and also figure out how to add multiple images to artworks.

I also realised we hadn't added the foreign keys for the artwork_collection join table, so that's sorted now. db:migrate required for those!