### PR TITLE
Add medium model

### DIFF
--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -1,5 +1,5 @@
 class Artwork < ApplicationRecord
-  belongs_to :user, :medium
+  belongs_to :user
   has_many :artwork_collections, dependent: :destroy
   has_many :collections, through: :artwork_collections
   has_many :bids, dependent: :destroy

--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -1,11 +1,9 @@
 class Artwork < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, :medium
   has_many :artwork_collections, dependent: :destroy
   has_many :collections, through: :artwork_collections
   has_many :bids, dependent: :destroy
   has_one_attached :photo
-
-  validates :medium, inclusion: { in: ["painting", "photography", "sculpture", "prints", "work on paper", "design", "drawing", "installation", "film/video"] }
 
   include PgSearch::Model
   pg_search_scope :global_search,

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,0 +1,2 @@
+class Medium < ApplicationRecord
+end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,2 +1,5 @@
 class Medium < ApplicationRecord
+  has_many :artworks
+
+  validates :medium, inclusion: { in: ["painting", "photography", "multi-media", "sculpture", "print", "design", "drawing"] }
 end

--- a/db/migrate/20230315103941_create_media.rb
+++ b/db/migrate/20230315103941_create_media.rb
@@ -1,0 +1,9 @@
+class CreateMedia < ActiveRecord::Migration[7.0]
+  def change
+    create_table :media do |t|
+      t.string :medium
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230315104946_remove_medium_from_artworks.rb
+++ b/db/migrate/20230315104946_remove_medium_from_artworks.rb
@@ -1,0 +1,4 @@
+class RemoveMediumFromArtworks < ActiveRecord::Migration[7.0]
+  def change
+  end
+end

--- a/db/migrate/20230315104946_remove_medium_from_artworks.rb
+++ b/db/migrate/20230315104946_remove_medium_from_artworks.rb
@@ -1,4 +1,5 @@
 class RemoveMediumFromArtworks < ActiveRecord::Migration[7.0]
   def change
+    remove_column :artworks, :medium, :string
   end
 end

--- a/db/migrate/20230315110336_add_medium_reference_to_artworks.rb
+++ b/db/migrate/20230315110336_add_medium_reference_to_artworks.rb
@@ -1,0 +1,5 @@
+class AddMediumReferenceToArtworks < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :artworks, :medium, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_15_104946) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_15_110336) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -63,6 +63,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_15_104946) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "end_time"
+    t.bigint "medium_id"
+    t.index ["medium_id"], name: "index_artworks_on_medium_id"
     t.index ["user_id"], name: "index_artworks_on_user_id"
   end
 
@@ -122,6 +124,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_15_104946) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "artwork_collections", "artworks"
   add_foreign_key "artwork_collections", "collections"
+  add_foreign_key "artworks", "media"
   add_foreign_key "artworks", "users"
   add_foreign_key "bids", "artworks"
   add_foreign_key "bids", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_04_175031) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_15_104946) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,6 +79,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_04_175031) do
   create_table "collections", force: :cascade do |t|
     t.string "title"
     t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "media", force: :cascade do |t|
+    t.string "medium"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,6 +13,7 @@ User.destroy_all
 Collection.destroy_all
 ArtworkCollection.destroy_all
 Bid.destroy_all
+Medium.destroy_all
 
 puts "Creating users..."
 
@@ -68,6 +69,14 @@ fourth_collection = Collection.create!(title: "Gems under £500", description: "
 file = URI.open("https://source.unsplash.com/random/?art")
 fourth_collection.photo.attach(io: file, filename: "fourth_collection.png", content_type: "image/png")
 fourth_collection.save!
+
+puts "Creating media..."
+
+media = ["painting", "photography", "multi-media", "sculpture", "print", "design", "drawing"]
+
+media.each do |medium|
+  Medium.create!(medium: medium.to_s)
+end
 
 puts "Creating art..."
 

--- a/test/models/medium_test.rb
+++ b/test/models/medium_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class MediumTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This branch is a dependency for editing the filter form on collection show page and artwork index. We've switched from having `medium` be a column in Artworks  table to having a separate `Media` table, connected to Artworks via foreign key, in a 1:N association. This should unblock progress on editing form_with from select-one dropdown to select-multiple checkbox.