### PR TITLE
move belongs_to medium to separate line in Artwork model, change seed…

### DIFF
--- a/app/models/artwork.rb
+++ b/app/models/artwork.rb
@@ -1,5 +1,6 @@
 class Artwork < ApplicationRecord
   belongs_to :user
+  belongs_to :medium
   has_many :artwork_collections, dependent: :destroy
   has_many :collections, through: :artwork_collections
   has_many :bids, dependent: :destroy

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,5 +1,3 @@
 class Medium < ApplicationRecord
   has_many :artworks
-
-  validates :medium, inclusion: { in: ["painting", "photography", "multi-media", "sculpture", "print", "design", "drawing"] }
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,15 +72,21 @@ fourth_collection.save!
 
 puts "Creating media..."
 
-media = ["painting", "photography", "multi-media", "sculpture", "print", "design", "drawing"]
+# media = ["Painting", "Photography", "Multi-media", "Sculpture", "Drawing", "Print"]
 
-media.each do |medium|
-  Medium.create!(medium: medium.to_s)
-end
+# media.each do |medium|
+#   Medium.create!(medium: medium.to_s)
+# end
+
+painting = Medium.create!(medium: "Painting")
+photography = Medium.create!(medium: "Photography")
+multimedia = Medium.create!(medium: "Multi-media")
+sculpture = Medium.create!(medium: "Sculpture")
+prints = Medium.create!(medium: "Print")
 
 puts "Creating art..."
 
-funk = Artwork.new(title: "Funk (Hardest Working Man)", price: 5000, user: david_boatwright, medium: "painting",
+funk = Artwork.new(title: "Funk (Hardest Working Man)", price: 5000, user: david_boatwright, medium: painting,
 height: 150, width: 300, year: "2020-01-01", material: "Oil on canvas", end_time: "2023-05-26 18:02:25")
 file = URI.open("http://www.luckyboyart.com/uploads/6/4/9/5/64954289/9932845_orig.jpg")
 funk.photo.attach(io: file, filename: "funk.jpg", content_type: "image/jpg")
@@ -88,7 +94,7 @@ funk.save!
 ArtworkCollection.create!(artwork: funk, collection: first_collection)
 first_collection.save!
 
-eleven_dollars = Artwork.new(title: "Eleven Dollars", price: 5000, user: david_boatwright, medium: "painting",
+eleven_dollars = Artwork.new(title: "Eleven Dollars", price: 5000, user: david_boatwright, medium: painting,
   height: 150, width: 300, year: "2020-01-01", material: "Oil on canvas", end_time: "2023-05-26 18:02:25")
 file = URI.open("http://www.luckyboyart.com/uploads/6/4/9/5/64954289/2947265_orig.jpg")
 eleven_dollars.photo.attach(io: file, filename: "eleven_dollars.jpg", content_type: "image/jpg")
@@ -96,7 +102,7 @@ eleven_dollars.save!
 ArtworkCollection.create!(artwork: eleven_dollars, collection: first_collection)
 first_collection.save!
 
-six_dollars = Artwork.new(title: "Six Dollars", price: 1000, user: david_boatwright, medium: "painting",
+six_dollars = Artwork.new(title: "Six Dollars", price: 1000, user: david_boatwright, medium: painting,
   height: 150, width: 300, year: "2020-01-01", material: "Oil on canvas", end_time: "2023-05-26 18:02:25")
 file = URI.open("http://www.luckyboyart.com/uploads/6/4/9/5/64954289/9086013_orig.jpg")
 six_dollars.photo.attach(io: file, filename: "six_dollars.jpg", content_type: "image/jpg")
@@ -104,7 +110,7 @@ six_dollars.save!
 ArtworkCollection.create!(artwork: six_dollars, collection: first_collection)
 first_collection.save!
 
-i_aint_know = Artwork.new(title: "I Ain't Know", price: 500, user: david_boatwright, medium: "painting",
+i_aint_know = Artwork.new(title: "I Ain't Know", price: 500, user: david_boatwright, medium: painting,
   height: 75, width: 100, year: "2020-01-01", material: "Limited edition giclee print", end_time: "2023-05-26 18:02:25")
 file = URI.open("http://www.luckyboyart.com/uploads/6/4/9/5/64954289/6223450_orig.jpg")
 i_aint_know.photo.attach(io: file, filename: "i_aint_know.jpg", content_type: "image/jpg")
@@ -112,7 +118,7 @@ i_aint_know.save!
 ArtworkCollection.create!(artwork: i_aint_know, collection: first_collection)
 first_collection.save!
 
-no_dice = Artwork.new(title: "No Dice", price: 4500, user: david_boatwright, medium: "painting",
+no_dice = Artwork.new(title: "No Dice", price: 4500, user: david_boatwright, medium: painting,
   height: 150, width: 200, year: "2017-01-01", material: "Oil on canvas", end_time: "2023-05-26 18:02:25")
 file = URI.open("http://www.luckyboyart.com/uploads/6/4/9/5/64954289/img-0348_orig.jpeg")
 no_dice.photo.attach(io: file, filename: "no_dice.jpg", content_type: "image/jpg")
@@ -122,7 +128,7 @@ first_collection.save!
 
 puts "Finished David's artwork!"
 
-jesus = Artwork.new(title: "Jesus", price: 7500, user: molly_b_right, medium: "painting",
+jesus = Artwork.new(title: "Jesus", price: 7500, user: molly_b_right, medium: painting,
   height: 200, width: 150, year: "2017-01-01", material: "Vintage bottlecap on metal", end_time: "2023-05-26 18:02:25")
 file = URI.open("https://mollybright.com/wp-content/uploads/2022/10/23409048512_2962ce4fa4_b.jpg")
 jesus.photo.attach(io: file, filename: "jesus.jpg", content_type: "image/jpg")
@@ -130,7 +136,7 @@ jesus.save!
 ArtworkCollection.create!(artwork: jesus, collection: second_collection)
 second_collection.save!
 
-mark_twain = Artwork.new(title: "Mark Twain", price: 7500, user: molly_b_right, medium: "painting",
+mark_twain = Artwork.new(title: "Mark Twain", price: 7500, user: molly_b_right, medium: painting,
   height: 200, width: 150, year: "2017-01-01", material: "Vintage bottlecap on metal", end_time: "2023-05-26 18:02:25")
 file = URI.open("https://mollybright.com/wp-content/uploads/2022/10/23517553855_404d8d1ecd_o.jpg")
 mark_twain.photo.attach(io: file, filename: "mark_twain.jpg", content_type: "image/jpg")
@@ -138,7 +144,7 @@ mark_twain.save!
 ArtworkCollection.create!(artwork: mark_twain, collection: second_collection)
 second_collection.save!
 
-amelia_earhart = Artwork.new(title: "Amelia Earhart", price: 7500, user: molly_b_right, medium: "painting",
+amelia_earhart = Artwork.new(title: "Amelia Earhart", price: 7500, user: molly_b_right, medium: painting,
   height: 200, width: 150, year: "2017-01-01", material: "Vintage bottlecap on metal", end_time: "2023-05-26 18:02:25")
 file = URI.open("https://mollybright.com/wp-content/uploads/2022/10/24022323322_78021decae_o.jpg")
 amelia_earhart.photo.attach(io: file, filename: "amelia_earhart.jpg", content_type: "image/jpg")
@@ -146,7 +152,7 @@ amelia_earhart.save!
 ArtworkCollection.create!(artwork: amelia_earhart, collection: second_collection)
 second_collection.save!
 
-frida_kahlo = Artwork.new(title: "Frida Kahlo", price: 7500, user: molly_b_right, medium: "painting",
+frida_kahlo = Artwork.new(title: "Frida Kahlo", price: 7500, user: molly_b_right, medium: painting,
   height: 200, width: 150, year: "2017-01-01", material: "Vintage bottlecap on metal", end_time: "2023-05-26 18:02:25")
 file = URI.open("https://mollybright.com/wp-content/uploads/2022/10/23517551885_9466035078_b.jpg")
 frida_kahlo.photo.attach(io: file, filename: "frida_kahlo.jpg", content_type: "image/jpg")
@@ -154,7 +160,7 @@ frida_kahlo.save!
 ArtworkCollection.create!(artwork: frida_kahlo, collection: second_collection)
 second_collection.save!
 
-queen_elizabeth = Artwork.new(title: "Queen Elizabeth", price: 7500, user: molly_b_right, medium: "painting",
+queen_elizabeth = Artwork.new(title: "Queen Elizabeth", price: 7500, user: molly_b_right, medium: painting,
   height: 200, width: 150, year: "2017-01-01", material: "Vintage bottlecap on metal", end_time: "2023-05-26 18:02:25")
 file = URI.open("https://mollybright.com/wp-content/uploads/2022/10/24064125266_aa13a14a46_o.jpg")
 queen_elizabeth.photo.attach(io: file, filename: "queen_elizabeth.jpg", content_type: "image/jpg")


### PR DESCRIPTION
Db:seed worked once, but not on subsequent attempts or on Heroku. Debugged by adding 'belongs_to :medium' to its own line and then had to change Medium population in the seed.db to less dry version. 