### PR TITLE
Fix artwork grid

### DIFF
--- a/app/assets/stylesheets/components/_artwork_card.scss
+++ b/app/assets/stylesheets/components/_artwork_card.scss
@@ -36,8 +36,8 @@
 .artwork-card-flexbox {
   display: inline-flex;
   flex-direction: column;
-  justify-content: space-between;
   flex-wrap: wrap;
+  justify-content: space-between;
   max-height: 1600px;
   width: 100%;
   margin: 24px;

--- a/app/assets/stylesheets/components/_artwork_card.scss
+++ b/app/assets/stylesheets/components/_artwork_card.scss
@@ -34,14 +34,9 @@
 }
 
 .artwork-column-container {
-  display: flex
-  // display: inline-flex;
-  // flex-direction: column;
-  // flex-wrap: wrap;
-  // justify-content: space-between;
-  // max-height: 1600px;
-  // width: 100%;
-  // margin: 24px;
+  display: flex;
+  justify-content: space-between;
+  margin: 24px;
 }
 
 .column-flex {

--- a/app/assets/stylesheets/components/_artwork_card.scss
+++ b/app/assets/stylesheets/components/_artwork_card.scss
@@ -26,6 +26,11 @@
 
 .artwork-card-body {
   width: 320px;
+  padding: 4px;
+}
+
+.artwork-card-body p {
+  margin-bottom: 0px;
 }
 
 .artwork-card-body a {

--- a/app/assets/stylesheets/components/_artwork_card.scss
+++ b/app/assets/stylesheets/components/_artwork_card.scss
@@ -33,12 +33,18 @@
   color: inherit;
 }
 
-.artwork-card-flexbox {
-  display: inline-flex;
+.artwork-column-container {
+  display: flex
+  // display: inline-flex;
+  // flex-direction: column;
+  // flex-wrap: wrap;
+  // justify-content: space-between;
+  // max-height: 1600px;
+  // width: 100%;
+  // margin: 24px;
+}
+
+.column-flex {
+  display: flex;
   flex-direction: column;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  max-height: 1600px;
-  width: 100%;
-  margin: 24px;
 }

--- a/app/controllers/artworks_controller.rb
+++ b/app/controllers/artworks_controller.rb
@@ -1,12 +1,20 @@
 class ArtworksController < ApplicationController
+
+  def assign_to_column(artworks)
+    artworks_array = artworks.in_groups(3)
+    column_1 = artworks_array[0].compact
+    column_2 = artworks_array[1].compact
+    column_3 = artworks_array[2].compact
+    @columns = [column_1, column_2, column_3]
+  end
+
   def index
-    @artworks = params[:query].present? ? Artwork.global_search(params[:query]) : Artwork.order(title: :asc)
+    artworks = params[:query].present? ? Artwork.global_search(params[:query]) : Artwork.order(title: :asc)
     if params[:user_location].present?
-      @artworks = Artwork.user.where(users: { location: params[:user_location] })
+      artworks = Artwork.user.where(users: { location: params[:user_location] })
     end
     if params[:medium_ids].present? && params[:medium_ids].size > 1
-      # media = params[:medium_ids].map |medium_id| { Medium.find(medium_id) }
-      @artworks = @artworks.where(medium_id: params[:medium_ids])
+      artworks = artworks.where(medium_id: params[:medium_ids])
     end
     if params[:price].present?
       price_range = params[:price].split(',')
@@ -17,14 +25,27 @@ class ArtworksController < ApplicationController
     if params[:size].present?
       case params[:size]
       when 'small'
-        @artworks = Artwork.select { |artwork| artwork.average_size < 40 }
+        artworks = Artwork.select { |artwork| artwork.average_size < 40 }
       when 'medium'
-        @artworks = Artwork.select { |artwork| artwork.average_size >= 40 && artwork.average_size <= 100 }
+        artworks = Artwork.select { |artwork| artwork.average_size >= 40 && artwork.average_size <= 100 }
       when 'large'
-        @artworks = Artwork.select { |artwork| artwork.average_size > 100 }
+        artworks = Artwork.select { |artwork| artwork.average_size > 100 }
       end
     end
+    assign_to_column(artworks)
   end
+
+  # def assign_to_column(artworks)
+  #   artworks_array = artworks.in_groups(3)
+  #   column_1 = artworks_array[0].compact
+  #   column_2 = artworks_array[1].compact
+  #   column_3 = artworks_array[2].compact
+  #   @columns = [column_1, column_2, column_3]
+  # end
+
+  # in view call column_1 = @columns[0]
+  # in view call @column_1 and fill column 1
+  # do the same for @column_2
 
   def show
     @artwork = Artwork.find(params[:id])

--- a/app/views/artworks/index.html.erb
+++ b/app/views/artworks/index.html.erb
@@ -1,7 +1,6 @@
 <div>
   <div>
     <h1>Browse artworks</h1>
-    <p><%= pluralize @artworks.count, "Artwork" %></p>
   </div>
   <div class="filter-container">
     <p>Filter by</p>
@@ -37,19 +36,28 @@
     <% end %>
   </div>
   <div>
-    <div class="row">
-      <% @artworks.each do |artwork| %>
-        <div class="artwork-card-body">
-          <%= link_to artwork_path(artwork) do %>
-              <%= cl_image_tag artwork.photo.key, width: 400, crop: :fill, class: "zoomable" %>
-              <div class="artwork-card-info">
-                <p class="artist-name"><%= artwork.user.first_name %> <%= artwork.user.last_name %></p>
-                <p class="artwork-title"><%= artwork.title %></p>
-                <p class="artwork-price"><%= number_to_currency(artwork.price, unit: "£", precision: 0) %></p>
-              </div>
-          <% end %>
-        </div>
+    <% @columns.each do |column| %>
+      <%column.each do |artwork| %>
+        <%= cl_image_tag artwork.photo.key, width: 320, crop: :fill, class: "zoomable" %>
+        <p class="artist-name"><%= artwork.user.first_name %><% artwork.user.last_name %></p>
       <% end %>
-    </div>
-  </div>
+    <% end %>
+
+
+    <%# <div class="artwork-card-flexbox">
+      <% @artworks.each do |artwork| %>
+        <%# <div class="artwork-card-body"> %>
+          <%# <%= link_to artwork_path(artwork) do %>
+              <%# <%= cl_image_tag artwork.photo.key, width: 320, crop: :fill, class: "zoomable" %>
+              <%# <div class="artwork-card-info"> %>
+                <%# <p class="artist-name"><%= artwork.user.first_name %>
+                <%# <%= artwork.user.last_name</p> %>
+                <%# <p class="artwork-title"><%= artwork.title</p> %>
+                <%# <p class="artwork-price"><%= number_to_currency(artwork.price, unit: "£", precision: 0)</p> %>
+              <%# </div> %>
+          <%# <% end %>
+        <%# </div> %>
+      <%# <% end %>
+    <%# </div> %>
+  <%# </div/> %>
 </div>

--- a/app/views/artworks/index.html.erb
+++ b/app/views/artworks/index.html.erb
@@ -39,8 +39,14 @@
     <% @columns.each do |column| %>
       <div class="column-flex">
         <%column.each do |artwork| %>
-          <%= cl_image_tag artwork.photo.key, width: 320, crop: :fill, class: "zoomable" %>
-          <p class="artist-name"><%= artwork.user.first_name %><%= artwork.user.last_name %></p>
+          <div class="artwork-card-body">
+            <%= link_to artwork_path(artwork) do %>
+              <%= cl_image_tag artwork.photo.key, width: 320, crop: :fill, class: "zoomable" %>
+              <p class="artist-name"><%= artwork.user.first_name %> <%= artwork.user.last_name %></p>
+              <p class="artwork-title"><%= artwork.title %></p>
+              <p class="artwork-price"><%= number_to_currency(artwork.price, unit: "£", precision: 0)%></p>
+            <% end %>
+          </div>
         <% end %>
       </div>
     <% end %>

--- a/app/views/artworks/index.html.erb
+++ b/app/views/artworks/index.html.erb
@@ -35,12 +35,14 @@
       </div>
     <% end %>
   </div>
-  <div>
+  <div class="artwork-column-container">
     <% @columns.each do |column| %>
-      <%column.each do |artwork| %>
-        <%= cl_image_tag artwork.photo.key, width: 320, crop: :fill, class: "zoomable" %>
-        <p class="artist-name"><%= artwork.user.first_name %><% artwork.user.last_name %></p>
-      <% end %>
+      <div class="column-flex">
+        <%column.each do |artwork| %>
+          <%= cl_image_tag artwork.photo.key, width: 320, crop: :fill, class: "zoomable" %>
+          <p class="artist-name"><%= artwork.user.first_name %><%= artwork.user.last_name %></p>
+        <% end %>
+      </div>
     <% end %>
 
 


### PR DESCRIPTION
The artworks controller and artwork view are edited such that all artworks are assigned to a columns instance variable in the controller. The artworks view now references @columns instead of @artworks and loops through an array of arrays to display artworks. 